### PR TITLE
Allow X11 forwarding

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -49,6 +49,7 @@
     settings = {
       PasswordAuthentication = false;
       KbdInteractiveAuthentication = false;
+      X11Forwarding = true;
     };
   };
 


### PR DESCRIPTION
This allows us to run graphical applications on the server, using X11 forwarding.